### PR TITLE
Make packet handlers scalable by using channels

### DIFF
--- a/boot/booter.go
+++ b/boot/booter.go
@@ -1,0 +1,60 @@
+package boot
+
+import (
+	"github.com/sirupsen/logrus"
+	"strings"
+)
+
+type bootComponent struct {
+	bootFunc          func()
+	amountOfInstances int
+}
+
+var _phases = make([]string, 0)
+var _componentsToBoot = make(map[string][]bootComponent)
+
+func SetPhases(phases ...string) {
+	_phases = toUpper(phases)
+}
+
+func RegisterComponent(phase string, bootFunc func(), times int) {
+	bootConf := bootComponent{bootFunc, times}
+	upperPhase := strings.ToUpper(phase)
+
+	if !phaseExists(phase) {
+		logrus.Warnf("registering component for yet unknown phase %s", upperPhase)
+	}
+
+	_componentsToBoot[upperPhase] = append(_componentsToBoot[upperPhase], bootConf)
+}
+
+func Boot() {
+	for _, phase := range _phases {
+		logrus.Infof("starting booting phase %s", phase)
+		for _, component := range _componentsToBoot[phase] {
+			for i := 0; i < component.amountOfInstances; i++ {
+				component.bootFunc()
+			}
+		}
+	}
+}
+
+func phaseExists(phase string) bool {
+	for _, p := range _phases {
+		if p == phase {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toUpper(phases []string) []string {
+	upper := make([]string, 0)
+
+	for _, phase := range phases {
+		upper = append(upper, strings.ToUpper(phase))
+	}
+
+	return upper
+}

--- a/server/backend_connection_handler.go
+++ b/server/backend_connection_handler.go
@@ -13,41 +13,46 @@ type BackendConnectionData struct {
 type BackendConnectionHandler struct {
 	BackendConnected chan BackendConnectionData
 	backendModules   map[string]string
+	channel          chan PacketChannelData
 }
 
-func NewBackendConnectionHandler(backendConnectedChannel chan BackendConnectionData, backedModules map[string]string) PacketHandler {
+func InitBackendConnectionHandler(backendConnectedChannel chan BackendConnectionData, backedModules map[string]string) {
 	handler := &BackendConnectionHandler{
 		BackendConnected: backendConnectedChannel,
 		backendModules:   backedModules,
+		channel:          PacketManagerInstance.GetQueue(opcode.BackendAuthentication),
 	}
-	PacketManagerInstance.RegisterHandler(opcode.BackendAuthentication, handler)
-	return handler
+
+	go handler.Handle()
 }
 
-func (h *BackendConnectionHandler) Handle(packet PacketChannelData) {
-	serverModuleId, err := packet.ReadString()
-	if err != nil {
-		log.Error("Could not read server name")
-	}
+func (h *BackendConnectionHandler) Handle() {
+	for {
+		packet := <-h.channel
+		serverModuleId, err := packet.ReadString()
+		if err != nil {
+			log.Error("Could not read server name")
+		}
 
-	secret, err := packet.ReadString()
-	if err != nil {
-		log.Error("Could not read secret")
-	}
+		secret, err := packet.ReadString()
+		if err != nil {
+			log.Error("Could not read secret")
+		}
 
-	if moduleSecret, exists := h.backendModules[serverModuleId]; exists {
-		if moduleSecret == secret {
-			log.Infof("%s connected", serverModuleId)
-			h.BackendConnected <- BackendConnectionData{
-				Session:  packet.Session,
-				ModuleID: serverModuleId,
+		if moduleSecret, exists := h.backendModules[serverModuleId]; exists {
+			if moduleSecret == secret {
+				log.Infof("%s connected", serverModuleId)
+				h.BackendConnected <- BackendConnectionData{
+					Session:  packet.Session,
+					ModuleID: serverModuleId,
+				}
+			} else {
+				log.Warnf("wrong secret for %s: %s. closing connection", serverModuleId, secret)
+				packet.Session.Conn.Close()
 			}
 		} else {
-			log.Warnf("wrong secret for %s: %s. closing connection", serverModuleId, secret)
+			log.Warnf("unknown backend module tried to connect: %s. closing connection", serverModuleId)
 			packet.Session.Conn.Close()
 		}
-	} else {
-		log.Warnf("unknown backend module tried to connect: %s. closing connection", serverModuleId)
-		packet.Session.Conn.Close()
 	}
 }

--- a/server/keep_alive_handler.go
+++ b/server/keep_alive_handler.go
@@ -1,13 +1,15 @@
 package server
 
-type KeepAliveHandler struct{}
-
-func NewKeepAliveHandler() PacketHandler {
-	handler := KeepAliveHandler{}
-	PacketManagerInstance.RegisterHandler(0x2002, handler)
-	return handler
+type KeepAliveHandler struct {
+	channel chan PacketChannelData
 }
 
-func (h KeepAliveHandler) Handle(packet PacketChannelData) {
+func InitKeepAliveHandler() {
+	queue := PacketManagerInstance.GetQueue(0x2002)
+	handler := KeepAliveHandler{channel: queue}
+	go handler.Handle()
+}
+
+func (h KeepAliveHandler) Handle() {
 	// Do Nothing
 }

--- a/server/key_exchange_handler.go
+++ b/server/key_exchange_handler.go
@@ -10,66 +10,71 @@ import (
 )
 
 type KeyExchangeHandler struct {
+	channel chan PacketChannelData
 }
 
-func NewKeyExchangeHandler() PacketHandler {
-	handler := KeyExchangeHandler{}
-	PacketManagerInstance.RegisterHandler(0x5000, handler)
-	return handler
+func InitKeyExchangeHandler() {
+	queue := PacketManagerInstance.GetQueue(0x5000)
+	handler := KeyExchangeHandler{channel: queue}
+	go handler.Handle()
 }
 
-func (keh KeyExchangeHandler) Handle(packet PacketChannelData) {
-	var err error
-	if !packet.Session.Context.StartedHandshake {
-		log.Error("Received handshake packet before handshake started")
+func (keh *KeyExchangeHandler) Handle() {
+	for {
+		var err error
+		packet := <-keh.channel
+		if !packet.Session.Context.StartedHandshake {
+			log.Error("Received handshake packet before handshake started")
+		}
+
+		// 1. Parse Handshake Response
+		packet.Context.RemotePublic, err = packet.ReadUInt32()
+		if err != nil {
+			log.Error("Could not read remote public")
+		}
+
+		packet.Session.Context.RemoteSignature, err = packet.ReadUInt64()
+		if err != nil {
+			log.Error("Could not read remote challenge")
+		}
+
+		// 2. Calculate Common Secret
+		packet.Session.Context.CommonSecret = security.G_pow_X_mod_P(packet.Session.Context.RemotePublic, packet.Session.Context.Private, packet.Session.Context.Prime)
+
+		// 3. derive new blowfish key
+		newBlowfishKey := security.CalculateKey(packet.Session.Context.CommonSecret, packet.Session.Context.LocalPublic, packet.Session.Context.RemotePublic)
+		packet.Session.Cipher, err = blowfish.NewCipher(newBlowfishKey)
+		if err != nil {
+			log.Error(err)
+		}
+
+		// 4. Decrypt remote challenge
+		keh.decryptRemoteChallenge(packet)
+
+		// 5. Compute signature
+		expectedSignature := utils2.ByteArrayToUint64(
+			security.CalculateChallenge(packet.Session.Context.CommonSecret, packet.Session.Context.RemotePublic, packet.Session.Context.LocalPublic))
+
+		// 6. Validate Remote signature
+		if expectedSignature != packet.Session.Context.RemoteSignature {
+			log.Errorf("Invalid client signature. Got = %v, want %v", packet.Session.Context.LocalSignature, packet.Session.Context.RemoteSignature)
+		}
+
+		// 7. Calculate Local Challenge
+		keh.calculateNewLocalChallenge(packet)
+
+		// 8. Generate final key
+		keh.deriveFinalKey(packet)
+
+		// 9. Send challenge
+		packet2 := network.EmptyPacket()
+		packet2.MessageID = 0x5000
+		packet2.WriteByte(network.EncodingKeyChallenge)
+		packet2.WriteUInt64(packet.Session.Context.LocalSignature)
+
+		packet.Session.Conn.Write(packet2.ToBytes())
+
 	}
-
-	// 1. Parse Handshake Response
-	packet.Context.RemotePublic, err = packet.ReadUInt32()
-	if err != nil {
-		log.Error("Could not read remote public")
-	}
-
-	packet.Session.Context.RemoteSignature, err = packet.ReadUInt64()
-	if err != nil {
-		log.Error("Could not read remote challenge")
-	}
-
-	// 2. Calculate Common Secret
-	packet.Session.Context.CommonSecret = security.G_pow_X_mod_P(packet.Session.Context.RemotePublic, packet.Session.Context.Private, packet.Session.Context.Prime)
-
-	// 3. derive new blowfish key
-	newBlowfishKey := security.CalculateKey(packet.Session.Context.CommonSecret, packet.Session.Context.LocalPublic, packet.Session.Context.RemotePublic)
-	packet.Session.Cipher, err = blowfish.NewCipher(newBlowfishKey)
-	if err != nil {
-		log.Error(err)
-	}
-
-	// 4. Decrypt remote challenge
-	keh.decryptRemoteChallenge(packet)
-
-	// 5. Compute signature
-	expectedSignature := utils2.ByteArrayToUint64(
-		security.CalculateChallenge(packet.Session.Context.CommonSecret, packet.Session.Context.RemotePublic, packet.Session.Context.LocalPublic))
-
-	// 6. Validate Remote signature
-	if expectedSignature != packet.Session.Context.RemoteSignature {
-		log.Errorf("Invalid client signature. Got = %v, want %v", packet.Session.Context.LocalSignature, packet.Session.Context.RemoteSignature)
-	}
-
-	// 7. Calculate Local Challenge
-	keh.calculateNewLocalChallenge(packet)
-
-	// 8. Generate final key
-	keh.deriveFinalKey(packet)
-
-	// 9. Send challenge
-	packet2 := network.EmptyPacket()
-	packet2.MessageID = 0x5000
-	packet2.WriteByte(network.EncodingKeyChallenge)
-	packet2.WriteUInt64(packet.Session.Context.LocalSignature)
-
-	packet.Session.Conn.Write(packet2.ToBytes())
 }
 
 func (keh KeyExchangeHandler) decryptRemoteChallenge(packet PacketChannelData) {

--- a/server/module_identification_handler.go
+++ b/server/module_identification_handler.go
@@ -6,29 +6,33 @@ import (
 )
 
 type ModuleIdentificationHandler struct {
+	channel chan PacketChannelData
 }
 
-func NewModuleIdentifactionHandler() PacketHandler {
-	handler := ModuleIdentificationHandler{}
-	PacketManagerInstance.RegisterHandler(0x2001, handler)
-	return handler
+func InitModuleIdentificationHandler() {
+	queue := PacketManagerInstance.GetQueue(0x2001)
+	handler := ModuleIdentificationHandler{channel: queue}
+	go handler.Handle()
 }
 
-func (mih ModuleIdentificationHandler) Handle(packet PacketChannelData) {
-	moduleName, err := packet.ReadString()
-	if err != nil {
-		log.Error("Could not read module name")
-	}
-	isLocalModule, err := packet.ReadByte()
-	if err != nil {
-		log.Error("Could not read if module is local or not")
-	}
+func (mih *ModuleIdentificationHandler) Handle() {
+	for {
+		packet := <-mih.channel
+		moduleName, err := packet.ReadString()
+		if err != nil {
+			log.Error("Could not read module name")
+		}
+		isLocalModule, err := packet.ReadByte()
+		if err != nil {
+			log.Error("Could not read if module is local or not")
+		}
 
-	log.Debugf("Module identified %v. Local: %v", moduleName, isLocalModule)
+		log.Debugf("Module identified %v. Local: %v", moduleName, isLocalModule)
 
-	p := network.EmptyPacket()
-	p.MessageID = 0x2001
-	p.WriteString(packet.Session.ServerModuleID)
-	p.WriteByte(0)
-	packet.Session.Conn.Write(p.ToBytes())
+		p := network.EmptyPacket()
+		p.MessageID = 0x2001
+		p.WriteString(packet.Session.ServerModuleID)
+		p.WriteByte(0)
+		packet.Session.Conn.Write(p.ToBytes())
+	}
 }

--- a/server/packet_handler.go
+++ b/server/packet_handler.go
@@ -1,5 +1,5 @@
 package server
 
 type PacketHandler interface {
-	Handle(packet PacketChannelData)
+	Handle()
 }

--- a/server/packet_manager.go
+++ b/server/packet_manager.go
@@ -1,23 +1,24 @@
 package server
 
 import (
-	"github.com/sirupsen/logrus"
 	"sync"
 )
 
 type PacketManager struct {
-	Handlers map[uint16]PacketHandler
-	mutex    sync.Mutex
+	queues map[uint16]chan PacketChannelData
+	mutex  sync.Mutex
 }
 
-func (pm *PacketManager) RegisterHandler(opcode uint16, handler PacketHandler) {
+func (pm *PacketManager) GetQueue(opcode uint16) chan PacketChannelData {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
-	if pm.Handlers[opcode] != nil {
-		logrus.Debugf("packet handler for opcode %X already registered\n", opcode)
-		return
+	if queue, exists := pm.queues[opcode]; exists {
+		return queue
+	} else {
+		queue := make(chan PacketChannelData, 128)
+		pm.queues[opcode] = queue
+		return queue
 	}
-	pm.Handlers[opcode] = handler
 }
 
-var PacketManagerInstance = &PacketManager{Handlers: make(map[uint16]PacketHandler)}
+var PacketManagerInstance = &PacketManager{queues: make(map[uint16]chan PacketChannelData)}


### PR DESCRIPTION
With this pull request, multiple packet handler instances for the same opcode can be created.
Packet handlers now use a packet queue, dedicated for the packet they are handling.
This queue is shared by other handlers of same type.
As channels do not duplicate their held values, the same packet is never sent to multiple instances of the handler type.

Also, a boot loader is introduced, which runs through different phases in order and executes provided init functions. 
This may be used to instantiate components without wiring up the initialisation code in the main function.